### PR TITLE
Update scartrace snakemake

### DIFF
--- a/singlecellmultiomics/snakemake_workflows/scartrace/Snakefile
+++ b/singlecellmultiomics/snakemake_workflows/scartrace/Snakefile
@@ -198,7 +198,7 @@ rule SCMO_maxInsert_filtering:
         stderr="log/insertSizeFilter/{library}.stderr"
 
     shell:
-        '''bamFilter.py {input.bam} -o {output.bam} 'r.has_tag("fe") and r.has_tag("fs") and (r.get_tag("fs") - r.get_tag("fe") < {params.insertSizeFilter})' > {log.stdout} 2> {log.stderr} '''
+        '''bamFilter.py {input.bam} -o {output.bam} 'r.has_tag("fS") and (r.get_tag("fS") < {params.insertSizeFilter})' > {log.stdout} 2> {log.stderr} '''
 
 #### 7. Librarystatistics
 rule SCMO_library_stats:

--- a/singlecellmultiomics/snakemake_workflows/scartrace/config.json
+++ b/singlecellmultiomics/snakemake_workflows/scartrace/config.json
@@ -1,9 +1,8 @@
 {
-    "reference_file"  :  "/hpc/hub_oudenaarden/group_references/ensembl/97/mus_musculus/SNP_MASKED.fa",
-    "reference_file_for_mapper" : "/hpc/hub_oudenaarden/group_references/ensembl/97/mus_musculus/SNP_MASKED.fa",
-    "mapper":"bwa", #bowtie2 or bwa
-    "alleles": "/hpc/hub_oudenaarden/group_references/variants/mgp.v5.merged.snps_all.dbSNP142.vcf.gz",
+    "reference_file_for_mapper" : "/hpc/hub_oudenaarden/Marloes/bin/masked_genome/primary_assembly_97_129B6Masked_ERCC92.fa",
+    "mapper": "bwa", #bowtie2 or bwa
+    "alleles": "/hpc/hub_oudenaarden/Marloes/bin/vcf/edited_hr_dbSNP_chr12-11468-11492_129Ola_129Sv_Bl6.vcf.gz",
     "allele_samples": "C57BL_6NJ,129S1_SvImJ",
     "SQ_filter": 0.98, # the minimum average phred score for each read - this discards low quality reads
-    "maxInsertSize":1000 # the maximum allowed distance between R1 and R2. This discards all read pairs where R1 and R2 are mapped to different amplicons
+    "maxInsertSize": 1000 # the maximum allowed distance between R1 and R2. This discards all read pairs where R1 and R2 are mapped to different amplicons
 }


### PR DESCRIPTION
- improved insert size filtering (snakefile)
- updated reference genome and vcf (config)
- removed unused parameter reference_file