### PR TITLE
96 well se addition

### DIFF
--- a/singlecellmultiomics/modularDemultiplexer/demultiplexModules/NLAIII.py
+++ b/singlecellmultiomics/modularDemultiplexer/demultiplexModules/NLAIII.py
@@ -87,3 +87,35 @@ class NLAIII_384w_c8_u3_SINGLE_END(UmiBarcodeDemuxMethod):
         taggedRecords = UmiBarcodeDemuxMethod.demultiplex(
             self, records, **kwargs)
         return taggedRecords
+
+        
+class NLAIII_96w_c8_u3_SINGLE_END(UmiBarcodeDemuxMethod):
+    def __init__(self, barcodeFileParser, **kwargs):
+        self.barcodeFileAlias = 'lennart96NLA'
+        UmiBarcodeDemuxMethod.__init__(
+            self,
+            umiRead=0,
+            umiStart=0,
+            umiLength=3,
+            barcodeRead=0,
+            barcodeStart=3,
+            barcodeLength=8,
+            random_primer_read=None,
+            random_primer_length=None,
+            barcodeFileAlias=self.barcodeFileAlias,
+            barcodeFileParser=barcodeFileParser,
+            **kwargs)
+        self.shortName = 'NLAIII96C8U3SE'
+        self.longName = 'NLAIII, 96 well CB: 8bp UMI: 3bp RP:6bp, single ended'
+        self.autoDetectable = True
+        self.description = '96 well format. 3bp umi followed by 8bp barcode. Single end: R2 is missing'
+
+    def demultiplex(self, records, **kwargs):
+
+        if kwargs.get('probe') and records[0].sequence[self.barcodeLength + \
+                      self.umiLength: self.barcodeLength + self.umiLength + 4] != 'CATG' or len(records)!=1:
+            raise NonMultiplexable
+
+        taggedRecords = UmiBarcodeDemuxMethod.demultiplex(
+            self, records, **kwargs)
+        return taggedRecords

--- a/singlecellmultiomics/modularDemultiplexer/demultiplexingStrategyLoader.py
+++ b/singlecellmultiomics/modularDemultiplexer/demultiplexingStrategyLoader.py
@@ -54,6 +54,7 @@ class DemultiplexingStrategyLoader:
             dm.NLAIII_96w_c8_u3,
             dm.Nla_384w_u8_c8_ad3_is15,
             dm.NLAIII_384w_c8_u3_SINGLE_END,
+            dm.NLAIII_96w_c8_u3_SINGLE_END,
 
             dm.SCCHIC_384w_c8_u3,
             dm.SCCHIC_384w_c8_u3_cs2,


### PR DESCRIPTION
Adds compatibility to single-end nla data with 96 barcodes