### PR TITLE
Velocyto compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
         'singlecellmultiomics/bamProcessing/bamToCountTable.py',
         'singlecellmultiomics/bamProcessing/bamCopyNumber.py',
         'singlecellmultiomics/bamProcessing/bamExtractSamples.py',
+        'singlecellmultiomics/bamProcessing/scmoConvert.py',
         'singlecellmultiomics/bamProcessing/bamToMethylationAndCopyNumber.py',
         'singlecellmultiomics/bamProcessing/bamToMethylationCalls.py',
         'singlecellmultiomics/bamProcessing/bamMappingRate.py',

--- a/singlecellmultiomics/bamProcessing/scmoConvert.py
+++ b/singlecellmultiomics/bamProcessing/scmoConvert.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import pysam
+import argparser
+
+def convert_scmo_to_cellranger(scmo_bam, cellranger_bam, n_threads=4):
+    """
+    Convert a SCMO bam file to a cellranger bam file
+    Adds these tags:
+        BC to CB
+        RX to UB
+    """
+
+    with pysam.AlignmentFile(scmo_bam,threads=n_threads) as al:
+        with pysam.AlignmentFile(cellranger_bam,  'wb', header=al.header, threads=n_threads) as ao:
+            for read in al:
+                if read.has_tag('BC'):
+                    read.set_tag('CB',read.get_tag('BC'))
+                if read.has_tag('RX'):
+                    read.set_tag('UB',read.get_tag('RX'))
+
+                ao.write(read)
+
+    pysam.index(cellranger_bam)
+
+
+def convert_scmo_to_dropseq(scmo_bam, dropseq_bam, n_threads=4):
+    """
+    Convert a SCMO bam file to a dropseq bam file
+    Adds these tags:
+        BC to XC
+        RX to XM
+    """
+    with pysam.AlignmentFile(scmo_bam,threads=n_threads) as al:
+        with pysam.AlignmentFile(dropseq_bam,  'wb', header=al.header, threads=n_threads) as ao:
+            for read in al:
+                if read.has_tag('BC'):
+                    read.set_tag('XC',read.get_tag('BC'))
+                if read.has_tag('RX'):
+                    read.set_tag('XM',read.get_tag('RX'))
+                ao.write(read)
+
+    pysam.index(dropseq_bam)
+
+if __name__ == '__main__':
+    argparser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="""Convert SCMO bam file to cellranger or dropseq bam file
+    """)
+    argparser.add_argument('inputbamfile', type=str)
+    argparser.add_argument('convertedbamfile', type=str)
+
+    og = argparser.add_argument_group("Output")
+    #og.add_argument('-bed', type=str, help='Bed file to write methylation calls to')
+    og.add_argument('-fmt', type=str, help='Format to convert to cellranger/dropseq', required=True)
+
+    args = argparser.parse_args()
+
+    if args.fmt == 'cellranger':
+        convert_scmo_to_cellranger(args.inputbamfile, args.convertedbamfile)
+    elif args.fmt == 'dropseq':
+        convert_scmo_to_dropseq(args.inputbamfile, args.convertedbamfile)

--- a/singlecellmultiomics/bamProcessing/scmoConvert.py
+++ b/singlecellmultiomics/bamProcessing/scmoConvert.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import pysam
-import argparser
+import argparse
 
 def convert_scmo_to_cellranger(scmo_bam, cellranger_bam, n_threads=4):
     """

--- a/singlecellmultiomics/molecule/featureannotatedmolecule.py
+++ b/singlecellmultiomics/molecule/featureannotatedmolecule.py
@@ -205,6 +205,12 @@ class FeatureAnnotatedMolecule(Molecule):
     def write_tags(self):
         Molecule.write_tags(self)
 
+        # Write cell ranger tags:
+        if self.umi is not None:
+            self.set_meta('UB', self.umi)
+        bc = list(self.get_barcode_sequences())[0]
+        self.set_meta('CB', bc)
+
         if len(self.exons) > 0:
             self.set_meta('EX', ','.join(sorted([str(x) for x in self.exons])))
         else:

--- a/singlecellmultiomics/molecule/molecule.py
+++ b/singlecellmultiomics/molecule/molecule.py
@@ -2940,3 +2940,18 @@ class Molecule():
                                     read.reference_name, rpos)] = -1
                     i += 1
         return methylated_positions, methylated_state
+
+
+    def _get_allele_from_reads(self) -> str:
+        """
+        Obtain associated allele based on the associated reads of the molecule
+
+        """
+        allele = None
+        for frag in self:
+            for read in frag:
+                if read is None or not read.has_tag('DA'):
+                    continue
+                allele = read.get_tag('DA')
+                return allele
+        return None


### PR DESCRIPTION
With this update all transcriptome SCMO bam files will be compatible with Velocyto.

First generate a bam file without duplicates:
`samtools view -F 1024 tagged.bam -bS  -@32 > unique.bam; samtools index unique.bam`
Then to obtain the loom file:
`velocyto run -o counts unique.bam [gtf_path] -U` 

### Previously generated bam files can be made compatible with Velocyto by running: 
`scmoConvert.py old_tagged.bam compatible.bam -fmt cellranger` 
Then continue with the steps (deduplication and counting) above.