### PR TITLE
Add mini nla test into CI

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -29,3 +29,6 @@ jobs:
         pip install pytest
         pip install .
         pytest
+    - name: Test with mini_nla_test.bam
+      run: |
+        ${GITHUB_WORKSPACE}/singlecellmultiomics/universalBamTagger/bamtagmultiome.py ${GITHUB_WORKSPACE}/data/mini_nla_test.bam -method nla -o tagged.bam


### PR DESCRIPTION
After playing with the example `bamtagmultiome.py input.bam -method nla -o tagged.bam` in [README.md](https://github.com/BuysDB/SingleCellMultiOmics) , I am aware that the example is not included in the CI. Maybe it is a good idea to put it into CI so we will be confident that the example is always reliable?